### PR TITLE
Use system IPFS (any source) if available

### DIFF
--- a/fission-cli.rb
+++ b/fission-cli.rb
@@ -4,7 +4,7 @@ class FissionCli < Formula
   url "https://github.com/fission-suite/cli/releases/download/v1.21.1/macOS-10.14.zip"
   sha256 "8941d62e8c7e0d5b0d9d476cf89d15202a0b858bfead2334e10473eb468b8b90"
 
-  depends_on :ipfs
+  depends_on :ipfs => :recommended
 
   def install
     bin.install "fission-cli-exe"

--- a/fission-cli.rb
+++ b/fission-cli.rb
@@ -4,7 +4,7 @@ class FissionCli < Formula
   url "https://github.com/fission-suite/cli/releases/download/v1.21.1/macOS-10.14.zip"
   sha256 "8941d62e8c7e0d5b0d9d476cf89d15202a0b858bfead2334e10473eb468b8b90"
 
-  depends_on "ipfs"
+  depends_on :ipfs
 
   def install
     bin.install "fission-cli-exe"


### PR DESCRIPTION
The Homebrew docs aren't SUPER clear on the matter, but this may help fix issues where someone has already installed IPFS from a source other than `brew`.

<img width="684" alt="Screen Shot 2019-11-13 at 22 48 53" src="https://user-images.githubusercontent.com/1052016/68807951-190f7e80-0669-11ea-88a0-7b2f4fd56f43.png">

This reads as though all you need is the dependency available on your `PATH`. IPFS is not _optional_ in our case, so no hashrocket.